### PR TITLE
Fatal errors with PHP 8.1

### DIFF
--- a/src/BitArray.php
+++ b/src/BitArray.php
@@ -81,6 +81,7 @@ class BitArray implements ArrayAccess, Countable, JsonSerializable
      * @param int $offset
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         if (!is_int($offset)) {
@@ -104,6 +105,7 @@ class BitArray implements ArrayAccess, Countable, JsonSerializable
      * @throws RangeException
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         $this->isValidOffset($offset);
@@ -122,6 +124,7 @@ class BitArray implements ArrayAccess, Countable, JsonSerializable
      * @throws RangeException
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $this->isValidOffset($offset);
@@ -146,6 +149,7 @@ class BitArray implements ArrayAccess, Countable, JsonSerializable
      * @throws RangeException
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         $this->offsetSet($offset, false);
@@ -156,6 +160,7 @@ class BitArray implements ArrayAccess, Countable, JsonSerializable
      *
      * @return int Returns the total length in bits of the array
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return $this->length;
@@ -205,6 +210,7 @@ class BitArray implements ArrayAccess, Countable, JsonSerializable
     /**
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/src/BloomFilter.php
+++ b/src/BloomFilter.php
@@ -114,6 +114,7 @@ class BloomFilter implements JsonSerializable
     /**
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/src/HasherList.php
+++ b/src/HasherList.php
@@ -89,6 +89,7 @@ class HasherList implements JsonSerializable
     /**
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/tests/src/HasherListTest.php
+++ b/tests/src/HasherListTest.php
@@ -38,7 +38,11 @@ class HasherListTest extends TestCase
      */
     public function testInvalidHashAlgo()
     {
-        $this->expectException(RuntimeException::class);
+        if ( PHP_VERSION_ID > 80000 ) {
+            $this->expectException(\ValueError::class);
+        } else {
+            $this->expectException(\RuntimeException::class);
+        }
         new HasherList('this-is-not-valid', 3, 200);
     }
 


### PR DESCRIPTION
While running tests against MediaWiki with PHP 8.1, I get errors like:

    PHP Fatal error:  During inheritance of JsonSerializable: Uncaught Return type of
	Pleo\BloomFilter\BitArray::jsonSerialize() should either be compatible with
    JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute
	should be used to temporarily suppress the notice